### PR TITLE
make correction to address spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```elixir
 def deps do
   [
-    {:web3x, "~> 0.6.3"}
+    {:web3x, "~> 0.6.4"}
   ]
 end
 ```

--- a/lib/web3x/contract.ex
+++ b/lib/web3x/contract.ex
@@ -32,7 +32,7 @@ defmodule Web3x.Contract do
   end
 
   @doc "Returns the current Contract GenServer's address"
-  @spec address(atom()) :: {:ok, binary()}
+  @spec address(atom()) :: binary() | nil
   def address(name) do
     GenServer.call(ContractManager, {:address, name})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Web3x.MixProject do
   def project do
     [
       app: :web3x,
-      version: "0.6.3",
+      version: "0.6.4",
       elixir: "~> 1.10",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
the address spec was incorrect, since it specifies {:ok, binary()} when it just returns a single value

another option is to always return an :ok tuple with {:ok, binary() | nil} if we want